### PR TITLE
Add inclusion of "memory" header

### DIFF
--- a/Source/calculator.h
+++ b/Source/calculator.h
@@ -7,6 +7,7 @@
 #include <complex>
 #include <algorithm>
 #include <utility>
+#include <memory>
 
 // * output
 #include <iostream>


### PR DESCRIPTION
std::shared_ptr's declaration is stored in <memory>. Compiling on Microsoft Windows station can be successfull in case of accidentaly implicit inclusion of this header. But on Linux or FreeBSD this header must by included explicitly.